### PR TITLE
Correct integral scale factor in tfce_transform

### DIFF
--- a/matlab_tfce_transform.m
+++ b/matlab_tfce_transform.m
@@ -31,7 +31,7 @@ for h = 1:ndh
     vals = vals + curvals;
 end
 tfced = NaN(size(img));
-tfced(:) = vals;
+tfced(:) = vals.*dh;
 
 end
 


### PR DESCRIPTION
Very minor change to normalise the TFCE integral. I think the numerical integral over h should be multiplied by the step size. This doesn't matter provided dh is always the same, but is necessary to compare values across different dh values.

I didn't want to change the interface but it is sometimes nice to have an adaptive scheme where you set the number of levels (ndh) directly rather than dh. This can reduce computation time if you have images with a wide range of peak values (so some would have many more integral h slices and be much slower). In this case normalising the integral properly is essential.

Thanks very much for the useful package!
